### PR TITLE
[BUG-FIX] search filter for admin tends to rerender complete component

### DIFF
--- a/src/components/organism/AdminProducts/index.tsx
+++ b/src/components/organism/AdminProducts/index.tsx
@@ -20,8 +20,7 @@ import {
 import Tabs from '../../molecule/Tabs'
 import AdminProductListItem from '../../molecule/AdminProductListItem';
 import StrictProductInfo from '../StrictProductInfo';
-import { request, REQUEST_TYPE } from "../../../hooks";
-
+import { filterData, request } from "../../../hooks";
 
 const tabData = [
     { 
@@ -40,9 +39,19 @@ const tabData = [
 
 const Component = (props: any) => {
     const {
-        productList, 
-        setProductList
+        productList,
+        childRef
     } = props;
+    
+    const [filteredProducts, setFilteredProducts] = React.useState<any>(productList);
+    React.useImperativeHandle(childRef, () => ({
+        productSearchHandler(event: React.SyntheticEvent) {
+            let target = event.target as HTMLInputElement;
+            let value = target.value;
+            const results =  filterData(value, productList);
+            setFilteredProducts(results);
+        }
+      }));
     const [currProduct, setCurrProduct] = React.useState<any>();
     const [currState, setCurrState] = React.useState(tabData[0].value);
     const handleState = (state:string) => {
@@ -67,7 +76,7 @@ const Component = (props: any) => {
     return (
         <>
             {
-                !productList && 
+                !filteredProducts && 
                 <Box sx={{
                     height: '100%', 
                     width: '100%', 
@@ -83,7 +92,7 @@ const Component = (props: any) => {
                 </Box>
             }
             {
-                productList && 
+                filteredProducts && 
                 <>
                 
                     <Box sx={{
@@ -94,8 +103,10 @@ const Component = (props: any) => {
                     alignItems: 'center',
                     flexDirection: 'column'
                 }}>
+                    {console.log(filteredProducts.length, 'length')}
                     {
-                        productList?.map((product: any) => {
+                       
+                       filteredProducts?.map((product: any) => {
                             return (
                                 <Card sx={{p: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', m: 2}}>
                                     <Typography>

--- a/src/components/page/Manager/index.tsx
+++ b/src/components/page/Manager/index.tsx
@@ -15,7 +15,8 @@ import {
     Inventory2Outlined,
     BadgeOutlined,
     ManageAccountsOutlined,
-    AddOutlined
+    AddOutlined,
+    Refresh
 } from "@mui/icons-material";
 import { TablePropsType } from '../../molecule/Table';
 import { 
@@ -28,17 +29,16 @@ import { baseTheme} from '../../../theme';
 import { STATUS, REQUEST_TYPE } from "../../../type";
 import {
     Modal,
-    Search
+    Search,
 } from '../../molecule';
 import AdminProducts from '../../organism/AdminProducts';
 import { filterData, request } from "../../../hooks";
-import {
-    TableContainer,
-} from '../../molecule';
 import moment from 'moment/moment.js';
 const Component = (props: any) => {
+    const inputRef = React.useRef<{ productSearchHandler: (event: React.SyntheticEvent) => void }>();
     const [products, setProducts] = React.useState<any>([]);
-    const [fileredProducts, setFilteredProducts] = React.useState<any>();
+    const [employee, setEmployee] = React.useState<any>([]);
+    const [fileredProducts, setFilteredProducts] = React.useState<any>(products);
     const [state, setState] = React.useState<STATUS>(STATUS.NOT_STARTED);
     const [isProductAddModalVisible, setProductAddModalVisibility] = React.useState<boolean>(false);
     const {
@@ -55,7 +55,6 @@ const Component = (props: any) => {
         ).then(data => {
             if(data && data.success){
                 setProducts(data.products);
-                setFilteredProducts(data.products);
             }
         })
     }, []);
@@ -66,20 +65,23 @@ const Component = (props: any) => {
     }
 
     const ProductsComponent = () => {
-        return <Box sx={{display: 'flex', justifyContent: 'center', height: '100%', width: '100%',  overflowY: 'scroll', flexWrap: 'wrap'}}>
-            {/* {
-                products?.map((product: any) => {
-                    return <ThemeProvider theme={baseTheme}> */}
-                        <AdminProducts productList={products} setProductList={setProducts}/>
-                        {/* <Box sx={{m: 1}}><Card product={product} /></Box> */}
-                    {/* </ThemeProvider>
-                }) */}
-            {/* } */}
+        return <Box 
+            sx={{
+                display: 'flex', 
+                justifyContent: 'center', 
+                height: '100%', 
+                width: '100%',  
+                overflowY: 'scroll', 
+                flexWrap: 'wrap'
+            }}
+        >
+                <AdminProducts productList={products} childRef={inputRef}/>
         </Box>
     }
 
     const EmployeesComponent = () => {
         return <>
+            {/* <TableContainer columns={employeeProcessedData?.columns} rows={employeeProcessed?.rows} /> */}
         </>
     }
 
@@ -89,10 +91,7 @@ const Component = (props: any) => {
     }
 
     const productSearchHandler = (event: React.SyntheticEvent) =>{
-        let target = event.target as HTMLInputElement;
-        let value = target.value;
-        const results = filterData(value, fileredProducts);
-        setFilteredProducts(results);
+        inputRef?.current?.productSearchHandler(event);
     }
 
     const addProductHandler = async () => {
@@ -104,7 +103,7 @@ const Component = (props: any) => {
 
     const productHandler = (productData: any) => {
         const newProduct = productData;
-        setProducts([newProduct, ...products])
+        setProducts([...products, newProduct])
     }
 
     const AddProduct = () => {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -69,20 +69,21 @@ function isDate(sDate: any) {
     return !isNaN(parseFloat(str)) // ...and ensure strings of whitespace fail
   }
 
+      
+
 function filterData(text: string, data: JSONDataType) {
-    const results: JSONDataType = {};
+    const results: JSONDataType = [];
 
   for (const key in data) {
-    if (typeof data[key] === 'object') {
-      const nestedResults = filterData(text, data[key] as JSONDataType);
-      if (Object.keys(nestedResults).length) {
-        results[key] = nestedResults;
-      }
-    } else if (typeof data[key] === 'string' && data[key].includes(text)) {
-      results[key] = data[key];
+    if(JSON.stringify(data[key]).includes(text)){
+      results.push(data[key])
     }
   }
-  return results
+  return results;
+}
+
+function jsonToArray(jsonData: JSONDataType) {
+  return Object.keys(jsonData).map((key) => jsonData[key]);
 }
 
 export {
@@ -92,5 +93,6 @@ export {
     deleteCart,
     isDate,
     isNumeric,
-    filterData
+    filterData, 
+    jsonToArray
 };


### PR DESCRIPTION
To resolve this bug, the filtered data state should be in **AdminProducts** component, so when admin tries to search anything it shall not **rerender** the component which contains the **Search** component. The problem I was facing is how can we change the filtered data state which is in child component, from the parent component. So here comes the **useImperativeHandle** react hook which helps us to achieve this.